### PR TITLE
New changes: More portable and works with CentOS 6.6, curl 7.19.7; New config parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ As soon as I check the issue, I will update the list.
 - Ubuntu 20.04 LTS
 - CentOS Linux release 7.6.1810
 - CentOS 6.6 (Final)
+- Debian GNU/Linux 10 (buster) *arm64*
 - ~Raspberry Pi OS 10 (buster) -- Tested on *Raspberry Pi 3 Model B+* by [*Jonathan Engqvist*](https://github.com/Nebour)~ (Tested on Old Version of Code) 
 
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ As soon as I check the issue, I will update the list.
 - Ubuntu 18.04.2 LTS
 - Ubuntu 20.04 LTS
 - CentOS Linux release 7.6.1810
+- CentOS 6.6 (Final)
 - ~Raspberry Pi OS 10 (buster) -- Tested on *Raspberry Pi 3 Model B+* by [*Jonathan Engqvist*](https://github.com/Nebour)~ (Tested on Old Version of Code) 
 
 

--- a/cloudflare_dynamic_ip_update.bash
+++ b/cloudflare_dynamic_ip_update.bash
@@ -5,8 +5,8 @@
 ## and update it to the Cloudflare DNS record after comparing ip address registered to Cloudflare
 ## basic shell scripting guide https://blog.gaerae.com/2015/01/bash-hello-world.html
 
-## Using dig command (https://en.wikipedia.org/wiki/Dig_(command)) to get current public IP address
-currentIP=$( (command -v dig 2>&1 >/dev/null && dig +short myip.opendns.com @resolver1.opendns.com) || curl -s checkip.amazonaws.com)
+## get current public IP address
+currentIP=$(curl -s checkip.amazonaws.com)
 if [ $? == 0 ] && [ ${currentIP} ]; then  ## when dig command run without error,
     ## Making substring, only retrieving ip address of this server
     ## https://stackabuse.com/substrings-in-bash/
@@ -21,8 +21,6 @@ fi
 ## Use Cloudflare API to retrieve recordIP
 ## https://api.cloudflare.com/
 ## Read configuration from separated cloudflare_config file (need to locate in the same directory)
-## https://stackoverflow.com/questions/10929453/read-a-file-line-by-line-assigning-the-value-to-a-variable
-## https://stackoverflow.com/questions/10586153/split-string-into-an-array-in-bash
 SCRIPT_PATH=$(cd $(dirname $0) && pwd)
 while IFS= read -r line || [[ -n "$line" ]]; do
 	case "$line" in
@@ -148,8 +146,8 @@ CMD
     unset content
 done
 
-unset count
 unset currentIP
+unset curlCommand
 unset key
 unset email
 unset zoneID
@@ -157,4 +155,5 @@ unset recordType
 unset recordName
 unset dnsID
 unset recordProxied
+unset count
 unset needUpdate

--- a/cloudflare_dynamic_ip_update.bash
+++ b/cloudflare_dynamic_ip_update.bash
@@ -39,7 +39,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
 			updateTarget=${line/Update-Target=/}
 		;;
 		Record-Type=*)
-			type=${line/Record-Type=/}
+			recordType=${line/Record-Type=/}
 		;;
 	esac
 done < $SCRIPT_PATH"/cloudflare_config"  ## use cloudflare_config file
@@ -74,7 +74,7 @@ while [ $updateTargetIndex -lt ${#updateTarget[@]} ]; do
     type=${recordType[updateTargetIndex]}
     
     ## run the commend to get other DNS record properties
-    content=$(eval "$curlCommand -X GET \"https://api.cloudflare.com/client/v4/zones/$zoneID/dns_records?name=${string}&type=${type}\"")
+    content=$(eval "$curlCommand -X GET \"https://api.cloudflare.com/client/v4/zones/$zoneID/dns_records?name=${name}&type=${type}\"")
 
     ## Parse JSON  https://stackoverflow.com/questions/42427371/cloudflare-api-cut-json-response
     ## Using jq  https://stedolan.github.io/jq/
@@ -127,13 +127,13 @@ count=0
 while [ $count -lt ${#needUpdate[@]} ]; do
     if [ ${needUpdate[count]} == 'True' ]; then
         echo "record IP needs to be updated for "${recordName[count]}" with recordType "${recordType[count]}
-        success=$(eval $(cat <<CMD
+        content=$(eval $(cat <<CMD
 $curlCommand -X PUT "https://api.cloudflare.com/client/v4/zones/$zoneID/dns_records/${dnsID[count]}" \
 --data '{"type":"'"${recordType[count]}"'","name":"'"${recordName[count]}"'","content":"'"$currentIP"'","proxied":'${recordProxied[count]}'}'
 CMD
         ))
 
-        if [ $(echo $content | jq '.success') = "true" ]; then
+        if [ "$(echo $content | jq '.success')" = "true" ]; then
             echo "Success update record IP of "${recordName[count]}" with recordType "${recordType[count]}
         else
             echo "Fail to update record IP of "${recordName[count]}" with recordType "${recordType[count]}

--- a/cloudflare_dynamic_ip_update.bash
+++ b/cloudflare_dynamic_ip_update.bash
@@ -24,24 +24,27 @@ fi
 ## https://stackoverflow.com/questions/10929453/read-a-file-line-by-line-assigning-the-value-to-a-variable
 ## https://stackoverflow.com/questions/10586153/split-string-into-an-array-in-bash
 SCRIPT_PATH=$(cd $(dirname $0) && pwd)
-readResult=""  ## Store configuration
 while IFS= read -r line || [[ -n "$line" ]]; do
-    readResult+=" "  ## Delimiter: space
-    readResult+="$line"
+	case "$line" in
+		Auth-Key=*)
+			key=${line/Auth-Key=/}
+		;;
+		Auth-Email=*)
+			email=${line/Auth-Email=/}
+		;;
+		Zone-ID=*)
+			zoneID=${line/Zone-ID=/}
+		;;
+		Update-Target=*)
+			updateTarget=${line/Update-Target=/}
+		;;
+		Record-Type=*)
+			type=${line/Record-Type=/}
+		;;
+	esac
 done < $SCRIPT_PATH"/cloudflare_config"  ## use cloudflare_config file
 unset IFS
 unset SCRIPT_PATH
-
-
-## After retrieve information from file, cut result string into configuration elements
-key=$(echo $(echo $readResult | cut -d' ' -f 1) | cut -d'=' -f 2)
-email=$(echo $(echo $readResult | cut -d' ' -f 2) | cut -d'=' -f 2)
-zoneID=$(echo $(echo $readResult | cut -d' ' -f 3) | cut -d'=' -f 2)
-IFS=',' read -r -a updateTarget <<< "$(echo $(echo $readResult | cut -d' ' -f 4) | cut -d'=' -f 2)"
-IFS=',' read -r -a recordType <<< "$(echo $(echo $readResult | cut -d' ' -f 5) | cut -d'=' -f 2)"
-unset readResult
-unset IFS
-
 
 ## If Auth-Email is empty, use Token Authentication.
 if [ "$email" = '' ]; then

--- a/cloudflare_dynamic_ip_update.bash
+++ b/cloudflare_dynamic_ip_update.bash
@@ -6,7 +6,7 @@
 ## basic shell scripting guide https://blog.gaerae.com/2015/01/bash-hello-world.html
 
 ## Using dig command (https://en.wikipedia.org/wiki/Dig_(command)) to get current public IP address
-currentIP=$(dig +short myip.opendns.com @resolver1.opendns.com)
+currentIP=$( (command -v dig 2>&1 >/dev/null && dig +short myip.opendns.com @resolver1.opendns.com) || curl -s checkip.amazonaws.com)
 if [ $? == 0 ] && [ ${currentIP} ]; then  ## when dig command run without error,
     ## Making substring, only retrieving ip address of this server
     ## https://stackabuse.com/substrings-in-bash/

--- a/cloudflare_dynamic_ip_update.bash
+++ b/cloudflare_dynamic_ip_update.bash
@@ -23,7 +23,7 @@ fi
 ## Read configuration from separated cloudflare_config file (need to locate in the same directory)
 ## https://stackoverflow.com/questions/10929453/read-a-file-line-by-line-assigning-the-value-to-a-variable
 ## https://stackoverflow.com/questions/10586153/split-string-into-an-array-in-bash
-SCRIPT_PATH=$(dirname $(realpath $0))
+SCRIPT_PATH=$(cd $(dirname $0) && pwd)
 readResult=""  ## Store configuration
 while IFS= read -r line || [[ -n "$line" ]]; do
     readResult+=" "  ## Delimiter: space


### PR DESCRIPTION
Hi,

I love to submit this new PR. The primary purpose was making it works under CentOS 6.6 so it will be more portable. On CentOS 6.6 Final (Desktop version), the script throws some errors related to:
- [realpath](https://mandoc.dev/realpath): command not found. I use a trick with cd & [pwd](https://mandoc.dev/pwd) which are always available in most systems.
- [dig](https://mandoc.dev/dig): command not found. This binary is also available by default. I use curl with checkip.amazonaws.com instead. checkip.amazonaws.com is hosted by Amazon AWS so I think it's very stable for lots of connections rather than other checkip URLs.
- [cut](https://mandoc.dev/cut): it parsed updateTarget and recordType incorrectly. So I came up with a new config parser which I think it's simpler and works even order of configs changed. It just like the way some Bash script parse its parameters. This way, I think it's easier to write a config writer and we still use the current config format. I tried to re-produce the weird behavour upon opening this PR but can't. I fixed a week ago on CentOS 6.6 without having time to commit until now.
- [curl](https://mandoc.dev/curl#OPTIONS): curl 7.19.7 doesn't support `-H @-` until 7.55.0
> Starting in 7.55.0, this option can take an argument in @filename style, which then adds a header for each line in the input file. Using @- will make curl read the header file from stdin

I tested the script on Docker containers which run:
- Ubuntu 18.04.2 LTS
- Ubuntu 20.04 LTS
- CentOS Linux release 7.6.1810
- CentOS 6.6 (Final)

 Let me know if you have any questions.

Thank you!