### PR TITLE
Use double bracket conditional compound / Instruction for alias setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,50 @@
 # Cloudflare Public Dynamic IP Update
+
 Updating public dynamic IP address to existing cloudflare DNS record  
 Only support chaning IP of A records. If you specifically want support for other records type, please open an issue.
 
 ## Requirement
+
 Using [curl](https://en.wikipedia.org/wiki/CURL) and [jq](https://stedolan.github.io/jq/) (Need to install **epel-release** prior to install jq in CentOS).  
-Check whether jq is installed on your system or not before use this script.<br>  
+Check whether jq is installed on your system or not before use this script.<br>
+
+If you "installed" `jq` by creating `alias` pointing to the executable, you need to do the following steps to use this script.
+
+1. set alias on your `~/.bashrc` file.
+2. Put the following commands on the bash files (after line 1) before running scripts.
+
+```
+## To load user's bash environment (load alias for jq)
+shopt -s expand_aliases
+source ~/.bashrc
+```
 
 **Need to run `configure.bash` once before execute `cloudflare_dynamic_ip_update.bash`.**  
 While running `configure.bash`, you are prompt to enter API token. The API token should have `Zone:Read` and `DNS:Edit` permission. If you need detailed guideline how to get API Token, please check [this document](https://github.com/hyecheol123/Cloudflare-Public-Dynamic-IP-Update/blob/master/docs/How_To_Issue_API_Token.md).
 
-
 ## Tested Environment
+
 If you used this code in other OS and confirm that it works successfully (in all situation), please make an issue with brief test result.<br/>
 As soon as I check the issue, I will update the list.
 
 #### Test Condition
+
 - Current IP is same as record's IP, must see the proper message indicating the identity
 - Current IP is not same as record's IP, record's IP must be updated and see the proper message indicating the record has been updated
 - Has no connection, and see the error message
 
 #### Tested OS List
+
 As the script has been modified a lot, the previous tested version list has been removed. You are welcome to create an issue with test results.
+
 - Ubuntu 20.04 LTS
-- Debian GNU/Linux 10 (buster) *arm64*
-  - Raspberry Pi OS Lite *arm32* [Issue #12, DanielSchetritt](https://github.com/hyecheol123/Cloudflare-Public-Dynamic-IP-Update/issues/12)
+- Debian GNU/Linux 10 (buster) _arm64_
+  - Raspberry Pi OS Lite _arm32_ [Issue #12, DanielSchetritt](https://github.com/hyecheol123/Cloudflare-Public-Dynamic-IP-Update/issues/12)
 
 ## Other contributors
-- [Rp70](https://github.com/Rp70) provides update to support API Token and records with same name. *[PR #5](https://github.com/hyecheol123/Cloudflare-Public-Dynamic-IP-Update/pull/5)*
 
+- [Rp70](https://github.com/Rp70) provides update to support API Token and records with same name. _[PR #5](https://github.com/hyecheol123/Cloudflare-Public-Dynamic-IP-Update/pull/5)_
 
 ## Contact
+
 If you have any question or want to report an error (or any other suggestion), simply make an issue with description.

--- a/cloudflare_dynamic_ip_update.bash
+++ b/cloudflare_dynamic_ip_update.bash
@@ -5,19 +5,15 @@
 ## and update it to the Cloudflare DNS record after comparing ip address registered to Cloudflare
 ## basic shell scripting guide https://blog.gaerae.com/2015/01/bash-hello-world.html
 
-## To load user's bash environment (load alias for jq)
-shopt -s expand_aliases
-source ~/.bashrc
-
 ## get current public IP address
 currentIP=$(curl -s checkip.amazonaws.com)
-if [ $? == 0 ] && [ ${currentIP} ]; then  ## when dig command run without error,
+if [[ $? == 0 ]] && [[ ${currentIP} ]]; then  ## when dig command run without error,
     ## Making substring, only retrieving ip address of this server
     ## https://stackabuse.com/substrings-in-bash/
     currentIP=$(echo $currentIP | cut -d'"' -f 2)
     echo "current public IP address is "$currentIP
 else  ## error happens,
-    echo "Check your internet connection, or google DNS server maybe interruptted"
+    echo "Check your internet connection"
     exit
 fi
 
@@ -30,33 +26,33 @@ zoneid=($(jq -r '."update-target"[].zone_id' $CONFIG_PATH))
 unset CONFIG_PATH
 
 # Error Checks
-if [ ${#name[@]} != ${#id[@]} ]; then
+if [[ ${#name[@]} != ${#id[@]} ]]; then
   echo "Config file Disrupted!!"
   echo "Please re-generate config.json file (run configure.bash)"
   exit
 fi
-if [ ${#name[@]} != ${#id[@]} ]; then
+if [[ ${#name[@]} != ${#id[@]} ]]; then
   echo "Config file Disrupted!!"
   echo "Please re-generate config.json file (run configure.bash)"
   exit
 fi
 
 index=0
-while [ $index -lt ${#id[@]} ]; do # For all update targets in config file
+while [[ $index -lt ${#id[@]} ]]; do # For all update targets in config file
   # Retrieve current DNS status
   dnsStatusAPICall=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${zoneid[index]}/dns_records/${id[index]}" \
                              -H "Authorization: Bearer $apiKey" \
                              -H "Content-Type:application/json" | jq .)
   
   # Check for status
-  if [ $(echo $dnsStatusAPICall | jq .success) != true ] || [ $(echo $dnsStatusAPICall | jq -r .result.name) != ${name[index]} ]; then
+  if [[ $(echo $dnsStatusAPICall | jq .success) != true ]] || [[ $(echo $dnsStatusAPICall | jq -r .result.name) != ${name[index]} ]]; then
     echo "Error Occurred While Accessing Current DNS Status"
     echo "May Caused by outdated config file. Please re-generate config.json file (run configure.bash)"
     exit
   fi
 
   # compare recordIP with currentIP
-  if [ $(echo $dnsStatusAPICall | jq -r .result.content) == $currentIP ]; then
+  if [[ $(echo $dnsStatusAPICall | jq -r .result.content) == $currentIP ]]; then
     echo "${name[index]}: no needs to update"
   else # Need to update
     proxied=$(echo $dnsStatusAPICall | jq -r .result.proxied)
@@ -74,7 +70,7 @@ while [ $index -lt ${#id[@]} ]; do # For all update targets in config file
     unset data
 
     # Check for result
-    if [ $(echo $updateResult | jq -r .success) != true ] || [ $(echo $updateResult | jq -r .result.content) != $currentIP ]; then
+    if [[ $(echo $updateResult | jq -r .success) != true ]] || [[ $(echo $updateResult | jq -r .result.content) != $currentIP ]]; then
       echo "Error While updating ${name[index]}"
     else
       echo "${name[index]}: successfully updated to $currentIP"

--- a/configure.bash
+++ b/configure.bash
@@ -3,10 +3,6 @@
 ## Author: Hyecheol (Jerry) Jang
 ## Shell script to generate cloudflare.config
 
-## To load user's bash environment (load alias for jq)
-shopt -s expand_aliases
-source ~/.bashrc
-
 # Prompt to get API token
 echo "Need Cloudflare API Token with Zone:Read and DNS:Edit Permission"
 echo "Please go to Cloudflare Website and Issue API Token and paste below"
@@ -17,7 +13,7 @@ read -p 'Paste API Token here: ' apiToken # Get API Token
 validToken=$(curl -s -X GET "https://api.cloudflare.com/client/v4/user/tokens/verify" \
                       -H "Authorization: Bearer $apiToken" \
                       -H "Content-Type:application/json" | jq .success)
-while [ $validToken != "true" ]; do
+while [[ $validToken != "true" ]]; do
   echo -e "Token Invalid, Please Double Check and Enter Token Agian \n"
   read -p 'Paste API Token here: ' apiToken # Get API Token
   validToken=$(curl -s -X GET "https://api.cloudflare.com/client/v4/user/tokens/verify" \
@@ -31,17 +27,18 @@ unset validToken
 apiCall=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones?per_page=50" \
                   -H "Authorization: Bearer $apiToken" \
                   -H "Content-Type: application/json")
-if [ $(echo $apiCall | jq .success) != true ]; then # Error Checking
+if [[ $(echo $apiCall | jq .success) != true ]]; then # Error Checking
   echo "API call Failed. This may caused by either cloudflare's API server error or poor connectivity of your server"
   echo "Please try again later"
   exit
 fi
 zoneCount=$(echo $apiCall | jq .result_info.count)
+echo "Found ${zoneCount} zone"
 
 # Get Zone ID
 zoneIDs=()
 index=0
-while [ $index -lt $zoneCount ]; do
+while [[ $index -lt $zoneCount ]]; do
   zoneIDs+=($(echo $apiCall | jq -r .result[$index].id ))
   index=$[$index+1]
 done
@@ -59,7 +56,7 @@ for zoneID in ${zoneIDs[@]}; do
                     -H "Authorization: Bearer $apiToken" \
                     -H "Content-Type: application/json" | jq .)
   
-  if [ $(echo $apiCall | jq .success) != true ]; then # Error Checking
+  if [[ $(echo $apiCall | jq .success) != true ]]; then # Error Checking
     echo "API call Failed. This may caused by either cloudflare's API server error or poor connectivity of your server"
     echo "Please try again later"
     exit
@@ -68,7 +65,7 @@ for zoneID in ${zoneIDs[@]}; do
   # Extract records that want to update
   recordCount=$(echo $apiCall | jq .result_info.count)
   index=0
-  while [ $index -lt $recordCount ]; do
+  while [[ $index -lt $recordCount ]]; do
     # display record name and prompt
     echo $(echo $apiCall | jq -r .result[$index].name )
     while :; do


### PR DESCRIPTION
Instruction to Load alias from ./bashrc
- To fix problems (jq is "installed" by adding alias pointing to the executables of jq) running script on Git Bash installed on Windows.
- Code tested on Windows 11 Git Bash / WSL and Ubuntu 20.04
Use double bracket conditional compound
- Code tested on Windows 11 WSL and Ubuntu 20.04

Close #13 